### PR TITLE
[Dk 419] page 끝 번호 값이 상이한 케이스 수정

### DIFF
--- a/src/main/kotlin/kr/kro/dokbaro/server/common/dto/response/PageResponse.kt
+++ b/src/main/kotlin/kr/kro/dokbaro/server/common/dto/response/PageResponse.kt
@@ -14,7 +14,7 @@ data class PageResponse<T>(
 			data: Collection<T>,
 		): PageResponse<T> =
 			PageResponse(
-				endPageNumber = totalElementCount / pageSize + 1,
+				endPageNumber = (totalElementCount - 1) / pageSize + 1,
 				data = data,
 			)
 	}

--- a/src/test/kotlin/kr/kro/dokbaro/server/common/dto/response/PageResponseTest.kt
+++ b/src/test/kotlin/kr/kro/dokbaro/server/common/dto/response/PageResponseTest.kt
@@ -1,0 +1,38 @@
+package kr.kro.dokbaro.server.common.dto.response
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class PageResponseTest :
+	StringSpec({
+
+		"page 끝 번호를 반환한다" {
+			PageResponse
+				.of(
+					10,
+					10,
+					emptyList<String>(),
+				).endPageNumber shouldBe 1
+
+			PageResponse
+				.of(
+					20,
+					10,
+					emptyList<String>(),
+				).endPageNumber shouldBe 2
+
+			PageResponse
+				.of(
+					15,
+					10,
+					emptyList<String>(),
+				).endPageNumber shouldBe 2
+
+			PageResponse
+				.of(
+					5,
+					10,
+					emptyList<String>(),
+				).endPageNumber shouldBe 1
+		}
+	})


### PR DESCRIPTION
endPageNumber 계산 오류를 수정하였습니다.

총 요소 개수 % 페이지 수 == 0 인 케이스에서 발생하여, 해당 케이스까지 고려하여 수정하였습니다 