### PR TITLE
[DK-425] 리뷰 total score 조회 시 난이도 값 기본으로 0 설정

### DIFF
--- a/src/main/kotlin/kr/kro/dokbaro/server/core/quizreview/application/service/QuizReviewQueryService.kt
+++ b/src/main/kotlin/kr/kro/dokbaro/server/core/quizreview/application/service/QuizReviewQueryService.kt
@@ -40,6 +40,12 @@ class QuizReviewQueryService(
 					it.difficultyLevel
 				}.groupBy { it }
 				.mapValues { (_, v) -> v.count() }
+				.toMutableMap()
+				.apply {
+					getOrPut(1) { 0 }
+					getOrPut(2) { 0 }
+					getOrPut(3) { 0 }
+				}
 
 		return QuizReviewTotalScore(
 			quizId = quizId,

--- a/src/test/kotlin/kr/kro/dokbaro/server/core/quizreview/application/service/QuizReviewQueryServiceTest.kt
+++ b/src/test/kotlin/kr/kro/dokbaro/server/core/quizreview/application/service/QuizReviewQueryServiceTest.kt
@@ -34,6 +34,21 @@ class QuizReviewQueryServiceTest :
 			quizReviewQueryService.findTotalScoreBy(1) shouldNotBe null
 		}
 
+		"퀴즈 총 점수 조회 시 선택한 난이도가 없으면 0개로 보여준다" {
+			every { readQuizReviewTotalScorePort.findBy(any()) } returns
+				listOf(QuizReviewTotalScoreElement(1, 3, 1))
+
+			quizReviewQueryService.findTotalScoreBy(1).difficulty!![2] shouldBe
+				QuizReviewTotalScore.DifficultyScore(selectCount = 0, selectRate = 0.0)
+			quizReviewQueryService.findTotalScoreBy(1).difficulty!![3] shouldBe
+				QuizReviewTotalScore.DifficultyScore(selectCount = 0, selectRate = 0.0)
+
+			every { readQuizReviewTotalScorePort.findBy(any()) } returns
+				listOf(QuizReviewTotalScoreElement(1, 3, 2))
+			quizReviewQueryService.findTotalScoreBy(1).difficulty!![1] shouldBe
+				QuizReviewTotalScore.DifficultyScore(selectCount = 0, selectRate = 0.0)
+		}
+
 		"퀴즈 총 점수 조회 시 quiz id에 해당하는 quiz가 없으면 난이도 및 별점에 null을 반환한다" {
 			every { readQuizReviewTotalScorePort.findBy(any()) } returns emptyList()
 


### PR DESCRIPTION
난이도 체크가 없는 경우, 기존에는 해당 부분을 아예 명시하지 않는 방식으로 응답값을 제공하였습니다.
클라이언트 요청에 따라 체크한 사람이 없더라도, 기본적으로 카운트를 0으로 응답하도록 변경하였습니다.