### PR TITLE
[DK-433] 회원 탈퇴 적용 안되는 현상 수정

### DIFF
--- a/src/main/kotlin/kr/kro/dokbaro/server/core/member/adapter/out/persistence/repository/jooq/MemberRepository.kt
+++ b/src/main/kotlin/kr/kro/dokbaro/server/core/member/adapter/out/persistence/repository/jooq/MemberRepository.kt
@@ -85,6 +85,7 @@ class MemberRepository(
 			.set(MEMBER.NICKNAME, member.nickname)
 			.set(MEMBER.EMAIL, member.email?.address)
 			.set(MEMBER.PROFILE_IMAGE_URL, member.profileImage)
+			.set(MEMBER.WITHDRAW, member.withdraw)
 			.where(MEMBER.ID.eq(member.id))
 			.execute()
 


### PR DESCRIPTION
- 회원 업데이트 시 회원 탈퇴 필드 업데이트 안되는 현상 수정했습니다.
- 회원 조회 시 탈퇴한 회원은 조회되지 않도록 수정했습니다.