### PR TITLE
[DK-444]: 푼 퀴즈 개수 조회 시 삭제된 퀴즈 제외

### DIFF
--- a/src/main/kotlin/kr/kro/dokbaro/server/core/solvingquiz/adapter/out/persistence/repository/jooq/SolvingQuizQueryRepository.kt
+++ b/src/main/kotlin/kr/kro/dokbaro/server/core/solvingquiz/adapter/out/persistence/repository/jooq/SolvingQuizQueryRepository.kt
@@ -166,6 +166,8 @@ class SolvingQuizQueryRepository(
 		dslContext
 			.selectCount()
 			.from(SOLVING_QUIZ)
+			.join(BOOK_QUIZ)
+			.on(BOOK_QUIZ.ID.eq(SOLVING_QUIZ.QUIZ_ID).and(BOOK_QUIZ.DELETED.isFalse))
 			.where(buildCountCondition(condition).and(SOLVING_QUIZ.DELETED.isFalse))
 			.fetchOneInto(Long::class.java)!!
 


### PR DESCRIPTION
푼 퀴즈 개수 조회 시 삭제된 퀴즈 제외하도록 쿼리를 변경하였습니다.