### PR TITLE
Fix(DK-482): SolvingQuizMapper.toStudyGroupSolvingQuizSheets null 반환 안되는 현상 수정

### DIFF
--- a/src/main/kotlin/kr/kro/dokbaro/server/core/solvingquiz/adapter/out/persistence/entity/jooq/SolvingQuizMapper.kt
+++ b/src/main/kotlin/kr/kro/dokbaro/server/core/solvingquiz/adapter/out/persistence/entity/jooq/SolvingQuizMapper.kt
@@ -155,7 +155,7 @@ class SolvingQuizMapper {
 							quizId = group.quizId,
 							sheets = sheets,
 						)
-					}.first()
+					}.firstOrNull()
 			}
 }
 


### PR DESCRIPTION
스터디 그룹 랭킹 조회 시 그룹 내 안 푼사람이 있을 경우 에러 발생하는 현상을 수정하였습니다.
