### PR TITLE
[DK-489]: 퀴즈 목록 조회 시 조회 범위에 따라 목록 노출 변경

### DIFF
--- a/src/main/kotlin/kr/kro/dokbaro/server/core/bookquiz/adapter/out/persistence/repository/jooq/BookQuizQueryRepository.kt
+++ b/src/main/kotlin/kr/kro/dokbaro/server/core/bookquiz/adapter/out/persistence/repository/jooq/BookQuizQueryRepository.kt
@@ -5,6 +5,7 @@ import kr.kro.dokbaro.server.common.dto.option.SortDirection
 import kr.kro.dokbaro.server.core.bookquiz.adapter.out.persistence.entity.jooq.BookQuizMapper
 import kr.kro.dokbaro.server.core.bookquiz.application.port.out.dto.BookQuizDetailQuestions
 import kr.kro.dokbaro.server.core.bookquiz.application.port.out.dto.CountBookQuizCondition
+import kr.kro.dokbaro.server.core.bookquiz.domain.AccessScope
 import kr.kro.dokbaro.server.core.bookquiz.query.BookQuizAnswer
 import kr.kro.dokbaro.server.core.bookquiz.query.BookQuizExplanation
 import kr.kro.dokbaro.server.core.bookquiz.query.BookQuizQuestions
@@ -131,6 +132,7 @@ class BookQuizQueryRepository(
 					)
 				}
 			},
+			condition.viewScope?.let { BOOK_QUIZ.VIEW_SCOPE.eq(it.name) },
 		)
 
 	fun findAllBookQuizSummary(
@@ -164,13 +166,18 @@ class BookQuizQueryRepository(
 				.leftJoin(QUIZ_REVIEW)
 				.on(QUIZ_REVIEW.QUIZ_ID.eq(BOOK_QUIZ.ID))
 				.where(
-					BOOK_QUIZ.BOOK_ID.eq(bookId).and(BOOK_QUIZ.DELETED.isFalse).and(
-						BOOK_QUIZ.ID
-							.notIn(
-								select(STUDY_GROUP_QUIZ.BOOK_QUIZ_ID)
-									.from(STUDY_GROUP_QUIZ),
-							),
-					),
+					BOOK_QUIZ.BOOK_ID
+						.eq(bookId)
+						.and(BOOK_QUIZ.DELETED.isFalse)
+						.and(
+							BOOK_QUIZ.ID
+								.notIn(
+									select(STUDY_GROUP_QUIZ.BOOK_QUIZ_ID)
+										.from(STUDY_GROUP_QUIZ),
+								),
+						).and(
+							BOOK_QUIZ.VIEW_SCOPE.eq(AccessScope.EVERYONE.name),
+						),
 				).groupBy(BOOK_QUIZ)
 				.orderBy(toBookQuizSummaryOrderQuery(pageOption), BOOK_QUIZ.ID)
 				.limit(pageOption.limit)

--- a/src/main/kotlin/kr/kro/dokbaro/server/core/bookquiz/adapter/out/persistence/repository/jooq/BookQuizRepository.kt
+++ b/src/main/kotlin/kr/kro/dokbaro/server/core/bookquiz/adapter/out/persistence/repository/jooq/BookQuizRepository.kt
@@ -159,7 +159,7 @@ class BookQuizRepository(
 				.select()
 				.from(BOOK_QUIZ)
 				.join(BOOK_QUIZ_QUESTION)
-				.on(BOOK_QUIZ_QUESTION.BOOK_QUIZ_ID.eq(BOOK_QUIZ.ID).and(BOOK_QUIZ_QUESTION.DELETED.eq(false)))
+				.on(BOOK_QUIZ_QUESTION.BOOK_QUIZ_ID.eq(BOOK_QUIZ.ID).and(BOOK_QUIZ_QUESTION.DELETED.isFalse))
 				.leftJoin(BOOK_QUIZ_SELECT_OPTION)
 				.on(BOOK_QUIZ_SELECT_OPTION.BOOK_QUIZ_QUESTION_ID.eq(BOOK_QUIZ_QUESTION.ID))
 				.leftJoin(BOOK_QUIZ_ANSWER)
@@ -168,7 +168,7 @@ class BookQuizRepository(
 				.on(STUDY_GROUP_QUIZ.BOOK_QUIZ_ID.eq(BOOK_QUIZ.ID))
 				.leftJoin(BOOK_QUIZ_ANSWER_EXPLAIN_IMAGE)
 				.on(BOOK_QUIZ_ANSWER_EXPLAIN_IMAGE.BOOK_QUIZ_QUESTION_ID.eq(BOOK_QUIZ_QUESTION.ID))
-				.where(BOOK_QUIZ.ID.eq(id).and(BOOK_QUIZ.DELETED.eq(false)))
+				.where(BOOK_QUIZ.ID.eq(id).and(BOOK_QUIZ.DELETED.isFalse))
 				.fetchGroups(BOOK_QUIZ)
 
 		return bookQuizMapper.toBookQuiz(record)

--- a/src/main/kotlin/kr/kro/dokbaro/server/core/bookquiz/application/port/out/dto/CountBookQuizCondition.kt
+++ b/src/main/kotlin/kr/kro/dokbaro/server/core/bookquiz/application/port/out/dto/CountBookQuizCondition.kt
@@ -1,10 +1,13 @@
 package kr.kro.dokbaro.server.core.bookquiz.application.port.out.dto
 
+import kr.kro.dokbaro.server.core.bookquiz.domain.AccessScope
+
 data class CountBookQuizCondition(
 	val bookId: Long? = null,
 	val creatorId: Long? = null,
 	val studyGroupId: Long? = null,
 	val solved: Solved? = null,
+	val viewScope: AccessScope? = null,
 ) {
 	data class Solved(
 		val memberId: Long,

--- a/src/main/kotlin/kr/kro/dokbaro/server/core/bookquiz/application/service/BookQuizQueryService.kt
+++ b/src/main/kotlin/kr/kro/dokbaro/server/core/bookquiz/application/service/BookQuizQueryService.kt
@@ -17,6 +17,7 @@ import kr.kro.dokbaro.server.core.bookquiz.application.port.out.ReadMyBookQuizSu
 import kr.kro.dokbaro.server.core.bookquiz.application.port.out.ReadUnsolvedGroupBookQuizPort
 import kr.kro.dokbaro.server.core.bookquiz.application.port.out.dto.CountBookQuizCondition
 import kr.kro.dokbaro.server.core.bookquiz.application.service.exception.NotFoundQuizException
+import kr.kro.dokbaro.server.core.bookquiz.domain.AccessScope
 import kr.kro.dokbaro.server.core.bookquiz.domain.exception.NotFoundQuestionException
 import kr.kro.dokbaro.server.core.bookquiz.query.BookQuizAnswer
 import kr.kro.dokbaro.server.core.bookquiz.query.BookQuizExplanation
@@ -54,7 +55,13 @@ class BookQuizQueryService(
 		bookId: Long,
 		pageOption: PageOption<BookQuizSummarySortKeyword>,
 	): PageResponse<BookQuizSummary> {
-		val count: Long = countBookQuizPort.countBookQuizBy(CountBookQuizCondition(bookId = bookId))
+		val count: Long =
+			countBookQuizPort.countBookQuizBy(
+				CountBookQuizCondition(
+					bookId = bookId,
+					viewScope = AccessScope.EVERYONE,
+				),
+			)
 		val data: Collection<BookQuizSummary> =
 			readBookQuizSummaryPort
 				.findAllBookQuizSummary(

--- a/src/test/kotlin/kr/kro/dokbaro/server/core/bookquiz/adapter/out/persistence/BookQuizPersistenceQueryAdapterTest.kt
+++ b/src/test/kotlin/kr/kro/dokbaro/server/core/bookquiz/adapter/out/persistence/BookQuizPersistenceQueryAdapterTest.kt
@@ -14,6 +14,7 @@ import kr.kro.dokbaro.server.core.bookquiz.adapter.out.persistence.entity.jooq.B
 import kr.kro.dokbaro.server.core.bookquiz.adapter.out.persistence.repository.jooq.BookQuizQueryRepository
 import kr.kro.dokbaro.server.core.bookquiz.adapter.out.persistence.repository.jooq.BookQuizRepository
 import kr.kro.dokbaro.server.core.bookquiz.application.port.out.dto.CountBookQuizCondition
+import kr.kro.dokbaro.server.core.bookquiz.domain.AccessScope
 import kr.kro.dokbaro.server.core.bookquiz.domain.AnswerSheet
 import kr.kro.dokbaro.server.core.bookquiz.domain.BookQuiz
 import kr.kro.dokbaro.server.core.bookquiz.domain.GradeSheetFactory
@@ -126,7 +127,7 @@ class BookQuizPersistenceQueryAdapterTest(
 					bookQuizFixture(creatorId = member, bookId = book, title = "hello$it", studyGroupId = studyGroup),
 				)
 				bookQuizRepository.insert(
-					bookQuizFixture(creatorId = member, bookId = book2, title = "hello$it"),
+					bookQuizFixture(creatorId = member, bookId = book2, title = "hello$it", viewScope = AccessScope.CREATOR),
 				)
 			}
 
@@ -134,6 +135,7 @@ class BookQuizPersistenceQueryAdapterTest(
 			adapter.countBookQuizBy(CountBookQuizCondition(studyGroupId = studyGroup)) shouldBe target
 			adapter.countBookQuizBy(CountBookQuizCondition(bookId = book2)) shouldBe target
 			adapter.countBookQuizBy(CountBookQuizCondition(creatorId = member)) shouldBe target
+			adapter.countBookQuizBy(CountBookQuizCondition(viewScope = AccessScope.CREATOR)) shouldBe target
 		}
 
 		"개수 조회 시 스터디 그룹을 명시하지 않으면 스터디 그룹을 제외하고 카운팅한다" {
@@ -175,6 +177,11 @@ class BookQuizPersistenceQueryAdapterTest(
 				CountBookQuizCondition(solved = CountBookQuizCondition.Solved(memberId = member, solved = true)),
 			) shouldBe
 				1
+			adapter.countBookQuizBy(
+				CountBookQuizCondition(solved = CountBookQuizCondition.Solved(memberId = member, solved = false)),
+			) shouldBe
+				2
+
 			adapter.countBookQuizBy(
 				CountBookQuizCondition(solved = CountBookQuizCondition.Solved(memberId = member, solved = false)),
 			) shouldBe


### PR DESCRIPTION
퀴즈 목록 조회 시 공개 범위와 상관 없이 전체 조회되던 방식을, viewScope에 따라 Everyone에만 조회되도록 변경하였습니다.