### PR TITLE
Release 1.1

### DIFF
--- a/src/main/kotlin/kr/kro/dokbaro/server/core/bookquiz/adapter/out/persistence/repository/jooq/BookQuizQueryRepository.kt
+++ b/src/main/kotlin/kr/kro/dokbaro/server/core/bookquiz/adapter/out/persistence/repository/jooq/BookQuizQueryRepository.kt
@@ -62,7 +62,7 @@ class BookQuizQueryRepository(
 					STUDY_GROUP_QUIZ.STUDY_GROUP_ID,
 				).from(BOOK_QUIZ)
 				.join(BOOK_QUIZ_QUESTION)
-				.on(BOOK_QUIZ_QUESTION.BOOK_QUIZ_ID.eq(BOOK_QUIZ.ID))
+				.on(BOOK_QUIZ_QUESTION.BOOK_QUIZ_ID.eq(BOOK_QUIZ.ID).and(BOOK_QUIZ_QUESTION.DELETED.isFalse))
 				.leftJoin(BOOK_QUIZ_SELECT_OPTION)
 				.on(BOOK_QUIZ_SELECT_OPTION.BOOK_QUIZ_QUESTION_ID.eq(BOOK_QUIZ_QUESTION.ID))
 				.leftJoin(STUDY_GROUP_QUIZ)
@@ -155,7 +155,8 @@ class BookQuizQueryRepository(
 							.from(BOOK_QUIZ_QUESTION)
 							.where(
 								BOOK_QUIZ_QUESTION.BOOK_QUIZ_ID
-									.eq(BOOK_QUIZ.ID),
+									.eq(BOOK_QUIZ.ID)
+									.and(BOOK_QUIZ_QUESTION.DELETED.isFalse),
 							),
 					).`as`(BookQuizRecordFieldName.BOOK_QUIZ_QUESTION_COUNT),
 				).from(BOOK_QUIZ)
@@ -362,7 +363,7 @@ class BookQuizQueryRepository(
 				.leftJoin(STUDY_GROUP_QUIZ)
 				.on(STUDY_GROUP_QUIZ.BOOK_QUIZ_ID.eq(BOOK_QUIZ.ID))
 				.join(BOOK_QUIZ_QUESTION)
-				.on(BOOK_QUIZ_QUESTION.BOOK_QUIZ_ID.eq(BOOK_QUIZ.ID))
+				.on(BOOK_QUIZ_QUESTION.BOOK_QUIZ_ID.eq(BOOK_QUIZ.ID).and(BOOK_QUIZ_QUESTION.DELETED.isFalse))
 				.where(BOOK_QUIZ.ID.eq(id))
 				.fetchGroups(BOOK_QUIZ)
 

--- a/src/main/kotlin/kr/kro/dokbaro/server/core/bookquiz/adapter/out/persistence/repository/jooq/BookQuizRepository.kt
+++ b/src/main/kotlin/kr/kro/dokbaro/server/core/bookquiz/adapter/out/persistence/repository/jooq/BookQuizRepository.kt
@@ -159,7 +159,7 @@ class BookQuizRepository(
 				.select()
 				.from(BOOK_QUIZ)
 				.join(BOOK_QUIZ_QUESTION)
-				.on(BOOK_QUIZ_QUESTION.BOOK_QUIZ_ID.eq(BOOK_QUIZ.ID).and(BOOK_QUIZ_QUESTION.DELETED.eq(false)))
+				.on(BOOK_QUIZ_QUESTION.BOOK_QUIZ_ID.eq(BOOK_QUIZ.ID).and(BOOK_QUIZ_QUESTION.DELETED.isFalse))
 				.leftJoin(BOOK_QUIZ_SELECT_OPTION)
 				.on(BOOK_QUIZ_SELECT_OPTION.BOOK_QUIZ_QUESTION_ID.eq(BOOK_QUIZ_QUESTION.ID))
 				.leftJoin(BOOK_QUIZ_ANSWER)
@@ -168,7 +168,7 @@ class BookQuizRepository(
 				.on(STUDY_GROUP_QUIZ.BOOK_QUIZ_ID.eq(BOOK_QUIZ.ID))
 				.leftJoin(BOOK_QUIZ_ANSWER_EXPLAIN_IMAGE)
 				.on(BOOK_QUIZ_ANSWER_EXPLAIN_IMAGE.BOOK_QUIZ_QUESTION_ID.eq(BOOK_QUIZ_QUESTION.ID))
-				.where(BOOK_QUIZ.ID.eq(id).and(BOOK_QUIZ.DELETED.eq(false)))
+				.where(BOOK_QUIZ.ID.eq(id).and(BOOK_QUIZ.DELETED.isFalse))
 				.fetchGroups(BOOK_QUIZ)
 
 		return bookQuizMapper.toBookQuiz(record)

--- a/src/main/kotlin/kr/kro/dokbaro/server/core/bookquiz/application/port/out/dto/CountBookQuizCondition.kt
+++ b/src/main/kotlin/kr/kro/dokbaro/server/core/bookquiz/application/port/out/dto/CountBookQuizCondition.kt
@@ -1,10 +1,13 @@
 package kr.kro.dokbaro.server.core.bookquiz.application.port.out.dto
 
+import kr.kro.dokbaro.server.core.bookquiz.domain.AccessScope
+
 data class CountBookQuizCondition(
 	val bookId: Long? = null,
 	val creatorId: Long? = null,
 	val studyGroupId: Long? = null,
 	val solved: Solved? = null,
+	val viewScope: AccessScope? = null,
 ) {
 	data class Solved(
 		val memberId: Long,

--- a/src/main/kotlin/kr/kro/dokbaro/server/core/bookquiz/application/service/BookQuizQueryService.kt
+++ b/src/main/kotlin/kr/kro/dokbaro/server/core/bookquiz/application/service/BookQuizQueryService.kt
@@ -17,6 +17,7 @@ import kr.kro.dokbaro.server.core.bookquiz.application.port.out.ReadMyBookQuizSu
 import kr.kro.dokbaro.server.core.bookquiz.application.port.out.ReadUnsolvedGroupBookQuizPort
 import kr.kro.dokbaro.server.core.bookquiz.application.port.out.dto.CountBookQuizCondition
 import kr.kro.dokbaro.server.core.bookquiz.application.service.exception.NotFoundQuizException
+import kr.kro.dokbaro.server.core.bookquiz.domain.AccessScope
 import kr.kro.dokbaro.server.core.bookquiz.domain.exception.NotFoundQuestionException
 import kr.kro.dokbaro.server.core.bookquiz.query.BookQuizAnswer
 import kr.kro.dokbaro.server.core.bookquiz.query.BookQuizExplanation
@@ -54,7 +55,13 @@ class BookQuizQueryService(
 		bookId: Long,
 		pageOption: PageOption<BookQuizSummarySortKeyword>,
 	): PageResponse<BookQuizSummary> {
-		val count: Long = countBookQuizPort.countBookQuizBy(CountBookQuizCondition(bookId = bookId))
+		val count: Long =
+			countBookQuizPort.countBookQuizBy(
+				CountBookQuizCondition(
+					bookId = bookId,
+					viewScope = AccessScope.EVERYONE,
+				),
+			)
 		val data: Collection<BookQuizSummary> =
 			readBookQuizSummaryPort
 				.findAllBookQuizSummary(

--- a/src/main/kotlin/kr/kro/dokbaro/server/core/bookquiz/domain/QuizQuestions.kt
+++ b/src/main/kotlin/kr/kro/dokbaro/server/core/bookquiz/domain/QuizQuestions.kt
@@ -19,10 +19,10 @@ data class QuizQuestions(
 				if (target.quizType != resentQuestion.quizType) {
 					throw QuizTypeMissMatchException()
 				}
-
-				questions.clear()
-				questions.addAll(newQuestions)
 			}
+
+		questions.clear()
+		questions.addAll(newQuestions)
 	}
 
 	fun grade(

--- a/src/main/kotlin/kr/kro/dokbaro/server/core/solvingquiz/adapter/out/persistence/entity/jooq/SolvingQuizMapper.kt
+++ b/src/main/kotlin/kr/kro/dokbaro/server/core/solvingquiz/adapter/out/persistence/entity/jooq/SolvingQuizMapper.kt
@@ -155,7 +155,7 @@ class SolvingQuizMapper {
 							quizId = group.quizId,
 							sheets = sheets,
 						)
-					}.first()
+					}.firstOrNull()
 			}
 }
 

--- a/src/main/kotlin/kr/kro/dokbaro/server/core/studygroup/application/service/StudyGroupService.kt
+++ b/src/main/kotlin/kr/kro/dokbaro/server/core/studygroup/application/service/StudyGroupService.kt
@@ -108,7 +108,7 @@ class StudyGroupService(
 
 		studyGroupAuthorityCheckService.checkUpdateStudyGroup(user, studyGroup)
 
-		studyGroup.changeStudyLeader(command.studyGroupId)
+		studyGroup.changeStudyLeader(command.newLeaderId)
 
 		updateStudyGroupPort.update(studyGroup)
 	}

--- a/src/test/kotlin/kr/kro/dokbaro/server/core/bookquiz/adapter/out/persistence/BookQuizPersistenceQueryAdapterTest.kt
+++ b/src/test/kotlin/kr/kro/dokbaro/server/core/bookquiz/adapter/out/persistence/BookQuizPersistenceQueryAdapterTest.kt
@@ -14,6 +14,7 @@ import kr.kro.dokbaro.server.core.bookquiz.adapter.out.persistence.entity.jooq.B
 import kr.kro.dokbaro.server.core.bookquiz.adapter.out.persistence.repository.jooq.BookQuizQueryRepository
 import kr.kro.dokbaro.server.core.bookquiz.adapter.out.persistence.repository.jooq.BookQuizRepository
 import kr.kro.dokbaro.server.core.bookquiz.application.port.out.dto.CountBookQuizCondition
+import kr.kro.dokbaro.server.core.bookquiz.domain.AccessScope
 import kr.kro.dokbaro.server.core.bookquiz.domain.AnswerSheet
 import kr.kro.dokbaro.server.core.bookquiz.domain.BookQuiz
 import kr.kro.dokbaro.server.core.bookquiz.domain.GradeSheetFactory
@@ -126,7 +127,7 @@ class BookQuizPersistenceQueryAdapterTest(
 					bookQuizFixture(creatorId = member, bookId = book, title = "hello$it", studyGroupId = studyGroup),
 				)
 				bookQuizRepository.insert(
-					bookQuizFixture(creatorId = member, bookId = book2, title = "hello$it"),
+					bookQuizFixture(creatorId = member, bookId = book2, title = "hello$it", viewScope = AccessScope.CREATOR),
 				)
 			}
 
@@ -134,6 +135,7 @@ class BookQuizPersistenceQueryAdapterTest(
 			adapter.countBookQuizBy(CountBookQuizCondition(studyGroupId = studyGroup)) shouldBe target
 			adapter.countBookQuizBy(CountBookQuizCondition(bookId = book2)) shouldBe target
 			adapter.countBookQuizBy(CountBookQuizCondition(creatorId = member)) shouldBe target
+			adapter.countBookQuizBy(CountBookQuizCondition(viewScope = AccessScope.CREATOR)) shouldBe target
 		}
 
 		"개수 조회 시 스터디 그룹을 명시하지 않으면 스터디 그룹을 제외하고 카운팅한다" {
@@ -175,6 +177,11 @@ class BookQuizPersistenceQueryAdapterTest(
 				CountBookQuizCondition(solved = CountBookQuizCondition.Solved(memberId = member, solved = true)),
 			) shouldBe
 				1
+			adapter.countBookQuizBy(
+				CountBookQuizCondition(solved = CountBookQuizCondition.Solved(memberId = member, solved = false)),
+			) shouldBe
+				2
+
 			adapter.countBookQuizBy(
 				CountBookQuizCondition(solved = CountBookQuizCondition.Solved(memberId = member, solved = false)),
 			) shouldBe

--- a/src/test/kotlin/kr/kro/dokbaro/server/core/bookquiz/domain/BookQuizTest.kt
+++ b/src/test/kotlin/kr/kro/dokbaro/server/core/bookquiz/domain/BookQuizTest.kt
@@ -66,6 +66,42 @@ class BookQuizTest :
 			bookQuiz.getAnswer(1) shouldNotBe null
 		}
 
+		"퀴즈 질문 수정을 진행한다." {
+			val bookQuiz =
+				bookQuizFixture(
+					questions =
+						listOf(
+							quizQuestionFixture(id = 1),
+						),
+				)
+
+			bookQuiz.updateQuestions(
+				listOf(
+					QuizQuestion(
+						content = "it.content",
+						selectOptions = listOf(),
+						answer =
+							QuestionAnswer(
+								explanationContent = "it.answerExplanationContent",
+								explanationImages = listOf(),
+								gradeSheet =
+									GradeSheetFactory.create(
+										type = QuizType.OX,
+										sheet = AnswerSheet(listOf("O")),
+									),
+							),
+					),
+				),
+				1,
+			)
+
+			bookQuiz.questions.getQuestions().size shouldBe 1
+			bookQuiz.questions
+				.getQuestions()
+				.first()
+				.answer.explanationImages
+				.shouldBeEmpty()
+		}
 		"설명 조회 시 question에 해당하는 ID가 없으면 예외를 반환한다" {
 			val bookQuiz = bookQuizFixture()
 


### PR DESCRIPTION
# 변경사항

1. 삭제된 퀴즈 조회되는 현상을 수정하였습니다. [DK-464] #18 
2. 스터디 그룹 랭킹 조회 시 그룹 내 안 푼사람이 있을 경우 에러 발생하는 현상을 수정하였습니다. [DK-482]  #19
3. 퀴즈 목록 조회 시 공개 범위와 상관 없이 전체 조회되던 방식을, viewScope에 따라 Everyone에만 조회되도록 변경하였습니다. [DK-489] #21
4. 스터디 그룹 리더 변경 시 오류 발생하는 현상을 수정하였습니다. [DK-492] #22

# 기타
퀴즈 임시저장 기능은 release 1.2 에 진행할 계획입니다. #20


[DK-464]: https://swm-kms.atlassian.net/browse/DK-464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DK-482]: https://swm-kms.atlassian.net/browse/DK-482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DK-489]: https://swm-kms.atlassian.net/browse/DK-489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DK-492]: https://swm-kms.atlassian.net/browse/DK-492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ