### PR TITLE
[DK-501] 퀴즈 개수 조회 시 study group에 대한 필터 세부화

### DIFF
--- a/src/main/kotlin/kr/kro/dokbaro/server/core/bookquiz/adapter/out/persistence/repository/jooq/BookQuizQueryRepository.kt
+++ b/src/main/kotlin/kr/kro/dokbaro/server/core/bookquiz/adapter/out/persistence/repository/jooq/BookQuizQueryRepository.kt
@@ -99,41 +99,49 @@ class BookQuizQueryRepository(
 			.where(buildCountCondition(condition).and(BOOK_QUIZ.DELETED.isFalse))
 			.fetchOneInto(Long::class.java)!!
 
-	private fun buildCountCondition(condition: CountBookQuizCondition): Condition =
-		DSL.and(
-			condition.bookId?.let { BOOK_QUIZ.BOOK_ID.eq(it) },
-			condition.creatorId?.let { BOOK_QUIZ.CREATOR_ID.eq(it) },
-			if (condition.studyGroupId != null) {
-				BOOK_QUIZ.ID
-					.`in`(
-						select(STUDY_GROUP_QUIZ.BOOK_QUIZ_ID)
-							.from(STUDY_GROUP_QUIZ)
-							.where(STUDY_GROUP_QUIZ.STUDY_GROUP_ID.eq(condition.studyGroupId)),
-					)
-			} else {
-				BOOK_QUIZ.ID
-					.notIn(
+	private fun buildCountCondition(condition: CountBookQuizCondition): Condition {
+		val result: Condition =
+			DSL.and(
+				condition.bookId?.let { BOOK_QUIZ.BOOK_ID.eq(it) },
+				condition.creatorId?.let { BOOK_QUIZ.CREATOR_ID.eq(it) },
+				condition.solved?.let {
+					if (it.solved) {
+						BOOK_QUIZ.ID.`in`(
+							select(SOLVING_QUIZ.QUIZ_ID)
+								.from(SOLVING_QUIZ)
+								.where(SOLVING_QUIZ.MEMBER_ID.eq(it.memberId)),
+						)
+					} else {
+						BOOK_QUIZ.ID.notIn(
+							select(SOLVING_QUIZ.QUIZ_ID)
+								.from(SOLVING_QUIZ)
+								.where(SOLVING_QUIZ.MEMBER_ID.eq(it.memberId)),
+						)
+					}
+				},
+				condition.viewScope?.let { BOOK_QUIZ.VIEW_SCOPE.eq(it.name) },
+			)
+
+		if (condition.studyGroup.active) {
+			if (condition.studyGroup.id == null) {
+				return result.and(
+					BOOK_QUIZ.ID.notIn(
 						select(STUDY_GROUP_QUIZ.BOOK_QUIZ_ID)
 							.from(STUDY_GROUP_QUIZ),
-					)
-			},
-			condition.solved?.let {
-				if (it.solved) {
-					BOOK_QUIZ.ID.`in`(
-						select(SOLVING_QUIZ.QUIZ_ID)
-							.from(SOLVING_QUIZ)
-							.where(SOLVING_QUIZ.MEMBER_ID.eq(it.memberId)),
-					)
-				} else {
-					BOOK_QUIZ.ID.notIn(
-						select(SOLVING_QUIZ.QUIZ_ID)
-							.from(SOLVING_QUIZ)
-							.where(SOLVING_QUIZ.MEMBER_ID.eq(it.memberId)),
-					)
-				}
-			},
-			condition.viewScope?.let { BOOK_QUIZ.VIEW_SCOPE.eq(it.name) },
-		)
+					),
+				)
+			}
+			return result.and(
+				BOOK_QUIZ.ID.`in`(
+					select(STUDY_GROUP_QUIZ.BOOK_QUIZ_ID)
+						.from(STUDY_GROUP_QUIZ)
+						.where(STUDY_GROUP_QUIZ.STUDY_GROUP_ID.eq(condition.studyGroup.id)),
+				),
+			)
+		}
+
+		return result
+	}
 
 	fun findAllBookQuizSummary(
 		bookId: Long,

--- a/src/main/kotlin/kr/kro/dokbaro/server/core/bookquiz/application/port/out/dto/CountBookQuizCondition.kt
+++ b/src/main/kotlin/kr/kro/dokbaro/server/core/bookquiz/application/port/out/dto/CountBookQuizCondition.kt
@@ -5,10 +5,19 @@ import kr.kro.dokbaro.server.core.bookquiz.domain.AccessScope
 data class CountBookQuizCondition(
 	val bookId: Long? = null,
 	val creatorId: Long? = null,
-	val studyGroupId: Long? = null,
+	val studyGroup: StudyGroup = StudyGroup(),
 	val solved: Solved? = null,
 	val viewScope: AccessScope? = null,
 ) {
+	data class StudyGroup(
+		val active: Boolean = false,
+		val id: Long? = null,
+	) {
+		companion object {
+			fun of(id: Long?): StudyGroup = StudyGroup(active = true, id = id)
+		}
+	}
+
 	data class Solved(
 		val memberId: Long,
 		val solved: Boolean,

--- a/src/main/kotlin/kr/kro/dokbaro/server/core/bookquiz/application/service/BookQuizQueryService.kt
+++ b/src/main/kotlin/kr/kro/dokbaro/server/core/bookquiz/application/service/BookQuizQueryService.kt
@@ -84,7 +84,7 @@ class BookQuizQueryService(
 		val totalCount: Long =
 			countBookQuizPort.countBookQuizBy(
 				CountBookQuizCondition(
-					studyGroupId = studyGroupId,
+					studyGroup = CountBookQuizCondition.StudyGroup.of(studyGroupId),
 					solved =
 						CountBookQuizCondition.Solved(
 							memberId = memberId,

--- a/src/test/kotlin/kr/kro/dokbaro/server/core/bookquiz/adapter/out/persistence/BookQuizPersistenceQueryAdapterTest.kt
+++ b/src/test/kotlin/kr/kro/dokbaro/server/core/bookquiz/adapter/out/persistence/BookQuizPersistenceQueryAdapterTest.kt
@@ -131,10 +131,13 @@ class BookQuizPersistenceQueryAdapterTest(
 				)
 			}
 
-			adapter.countBookQuizBy(CountBookQuizCondition(bookId = book)) shouldBe 0
-			adapter.countBookQuizBy(CountBookQuizCondition(studyGroupId = studyGroup)) shouldBe target
+			adapter.countBookQuizBy(CountBookQuizCondition(bookId = book)) shouldBe target
+			adapter.countBookQuizBy(
+				CountBookQuizCondition(studyGroup = CountBookQuizCondition.StudyGroup.of(studyGroup)),
+			) shouldBe
+				target
 			adapter.countBookQuizBy(CountBookQuizCondition(bookId = book2)) shouldBe target
-			adapter.countBookQuizBy(CountBookQuizCondition(creatorId = member)) shouldBe target
+			adapter.countBookQuizBy(CountBookQuizCondition(creatorId = member)) shouldBe target * 2
 			adapter.countBookQuizBy(CountBookQuizCondition(viewScope = AccessScope.CREATOR)) shouldBe target
 		}
 
@@ -157,8 +160,11 @@ class BookQuizPersistenceQueryAdapterTest(
 				)
 			}
 
-			adapter.countBookQuizBy(CountBookQuizCondition(studyGroupId = studyGroup)) shouldBe target
-			adapter.countBookQuizBy(CountBookQuizCondition()) shouldBe target
+			adapter.countBookQuizBy(
+				CountBookQuizCondition(studyGroup = CountBookQuizCondition.StudyGroup.of(null)),
+			) shouldBe
+				target
+			adapter.countBookQuizBy(CountBookQuizCondition()) shouldBe target * 2
 		}
 
 		"내가 푼 퀴즈 개수를 조회한다" {


### PR DESCRIPTION
Study Group이 active여야만 필터 적용하도록 변경하였습니다.
active가 false 이면 전체 목록 가져오고,
active가 true이고, studyGroupId가 null 이면, StudyGroup Quiz가 아닌 것의 개수를 조회하도록 변경하였습니다.
